### PR TITLE
Add proper image preprocessing with models specs and test coverage for the other 5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ script/test
 
 Query the running tensorflow-serving Docker container instance with:
 ```
-tensorflow_serving_client --host localhost --port 9001 --image tests/fixtures/files/cat.jpg --model mobilenet_v1-1 --size 224x224
+tensorflow_serving_client --host localhost --port 9000 --image tests/fixtures/files/cat.jpg --size 224x224
 ```

--- a/bin/tensorflow_serving_client
+++ b/bin/tensorflow_serving_client
@@ -3,20 +3,23 @@ import argparse
 import json
 
 from tensorflow_serving_client import TensorflowServingClient
+from tensorflow_serving_client.utils import load_image
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--host', required=True, type=str, help='Hostname to query')
     parser.add_argument('--port', required=True, type=int, help='Port to query')
-    parser.add_argument('--model', required=True, type=str, help='Name of the model spec to query')
+    parser.add_argument('--model', default=None, type=str, help='Name of the model spec to query')
     parser.add_argument('--image', required=True, type=str, help='Image to send (JPG format)')
     parser.add_argument('--size', required=True, type=str, help='Resize the image to this target size')
     args = parser.parse_args()
 
     target_size = [int(i) for i in args.size.split('x')]
 
-    client = TensorflowServingClient(args.host, args.port, args.model, target_size)
-    results = client.classify_image(args.image)
+    client = TensorflowServingClient(args.host, args.port)
+    image_data = load_image(args.image, target_size)
+    response = client.make_prediction(image_data, 'image')
+    predictions = response['class_probabilities'][0].tolist()
 
-    print(json.dumps(results, indent=4, sort_keys=True))
+    print(json.dumps(predictions, indent=4, sort_keys=True))

--- a/bin/tensorflow_serving_client
+++ b/bin/tensorflow_serving_client
@@ -3,25 +3,24 @@ import argparse
 import json
 
 from tensorflow_serving_client import TensorflowServingClient
-from tensorflow_serving_client.utils import load_image
+from tensorflow_serving_client.utils import load_image, MODEL_SPECS
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--host', required=True, type=str, help='Hostname to query')
     parser.add_argument('--port', required=True, type=int, help='Port to query')
-    parser.add_argument('--model', default=None, type=str, help='Name of the model spec to query')
+    parser.add_argument('--model_spec', default=None, type=str, help='Name of the model spec')
+    parser.add_argument('--model_name', required=True, type=str, help='Name of the model to query')
     parser.add_argument('--image', required=True, type=str, help='Image to send (JPG format)')
-    parser.add_argument('--size', required=True, type=str, help='Resize the image to this target size')
     args = parser.parse_args()
 
-    target_size = [int(i) for i in args.size.split('x')]
+    model_spec = MODEL_SPECS[args.model_spec]
 
     client = TensorflowServingClient(args.host, args.port)
-    # TODO (snormore): note that this utils.load_image performs 
-    # the Inception style input preprocessing, this is not consistent 
-    # across other models.
-    image_data = load_image(args.image, target_size)
+    image_data = load_image(args.image,
+                            model_spec['target_size'],
+                            model_spec['preprocess_input'])
     response = client.make_prediction(image_data, 'image')
     predictions = response['class_probabilities'][0].tolist()
 

--- a/bin/tensorflow_serving_client
+++ b/bin/tensorflow_serving_client
@@ -18,6 +18,9 @@ if __name__ == '__main__':
     target_size = [int(i) for i in args.size.split('x')]
 
     client = TensorflowServingClient(args.host, args.port)
+    # TODO (snormore): note that this utils.load_image performs 
+    # the Inception style input preprocessing, this is not consistent 
+    # across other models.
     image_data = load_image(args.image, target_size)
     response = client.make_prediction(image_data, 'image')
     predictions = response['class_probabilities'][0].tolist()

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,27 @@ jobs:
       - image: snormore/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
+          PORT: 9001
+      - image: snormore/tensorflow-serving-http:1
+        environment:
+          MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
+          PORT: 9002
+      - image: snormore/tensorflow-serving-http:1
+        environment:
+          MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
+          PORT: 9003
+      - image: snormore/tensorflow-serving-http:1
+        environment:
+          MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
+          PORT: 9004
+      - image: snormore/tensorflow-serving-http:1
+        environment:
+          MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
+          PORT: 9005
+      - image: snormore/tensorflow-serving-http:1
+        environment:
+          MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg19.tar.gz
+          PORT: 9006
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -4,27 +4,27 @@ jobs:
     working_directory: ~/tensorflow-serving-client
     docker:
       - image: circleci/python:3.6.1
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
           PORT: 9001
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
           PORT: 9002
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
           PORT: 9003
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
           PORT: 9004
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
           PORT: 9005
-      - image: snormore/tensorflow-serving-http:1
+      - image: snormore/tensorflow-serving-http:2
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg19.tar.gz
           PORT: 9006

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,9 @@ jobs:
     working_directory: ~/tensorflow-serving-client
     docker:
       - image: circleci/python:3.6.1
-      - image: snormore/tensorflow-serving-http
+      - image: snormore/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
-          MODEL_NAME: mobilenet_v1
-          MODEL_VERSION: 1
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -4,27 +4,27 @@ jobs:
     working_directory: ~/tensorflow-serving-client
     docker:
       - image: circleci/python:3.6.1
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
           PORT: 9001
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
           PORT: 9002
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
           PORT: 9003
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
           PORT: 9004
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
           PORT: 9005
-      - image: snormore/tensorflow-serving-http:2
+      - image: triage/tensorflow-serving-http:1
         environment:
           MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg19.tar.gz
           PORT: 9006

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,38 @@
 version: '3'
 services:
-  serving:
+  mobilenet_v1:
     image: snormore/tensorflow-serving-http:1
     ports:
-      - "9000:9000"
+      - "9001:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
+  inception_v3:
+    image: snormore/tensorflow-serving-http:1
+    ports:
+      - "9002:9000"
+    environment:
+      MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
+  xception:
+    image: snormore/tensorflow-serving-http:1
+    ports:
+      - "9003:9000"
+    environment:
+      MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
+  resnet50:
+    image: snormore/tensorflow-serving-http:1
+    ports:
+      - "9004:9000"
+    environment:
+      MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
+  vgg16:
+    image: snormore/tensorflow-serving-http:1
+    ports:
+      - "9005:9000"
+    environment:
+      MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
+  vgg19:
+    image: snormore/tensorflow-serving-http:1
+    ports:
+      - "9006:9000"
+    environment:
+      MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg19.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,37 @@
 version: '3'
 services:
   mobilenet_v1:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9001:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
   inception_v3:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9002:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
   xception:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9003:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
   resnet50:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9004:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
   vgg16:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9005:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
   vgg19:
-    image: snormore/tensorflow-serving-http:1
+    image: snormore/tensorflow-serving-http:2
     ports:
       - "9006:9000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,37 @@
 version: '3'
 services:
   mobilenet_v1:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9001:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
   inception_v3:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9002:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/inception_v3.tar.gz
   xception:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9003:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/xception.tar.gz
   resnet50:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9004:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/resnet50.tar.gz
   vgg16:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9005:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/vgg16.tar.gz
   vgg19:
-    image: snormore/tensorflow-serving-http:2
+    image: triage/tensorflow-serving-http:1
     ports:
       - "9006:9000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
 version: '3'
 services:
   serving:
-    image: snormore/tensorflow-serving-http
+    image: snormore/tensorflow-serving-http:1
     ports:
       - "9000:9000"
     environment:
       MODEL_URL: https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/mobilenet_v1.tar.gz
-      MODEL_NAME: mobilenet_v1
-      MODEL_VERSION: 1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ class BuildPackageProtos(install):
 
 setup(
     name='tensorflow_serving_client',
-    version='0.0.4',
+    version='0.0.5',
     description='Python client for tensorflow serving',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ class BuildPackageProtos(install):
 
 setup(
     name='tensorflow_serving_client',
-    version='0.0.3',
+    version='0.0.4',
     description='Python client for tensorflow serving',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tensorflow_serving_client/client.py
+++ b/tensorflow_serving_client/client.py
@@ -16,9 +16,9 @@ class TensorflowServingClient(object):
     def execute(self, request, timeout=10.0):
         return self.stub.Predict(request, timeout)
 
-    def make_prediction(self, input_data, input_tensor_name, timeout=10.0, model_name='model'):
+    def make_prediction(self, input_data, input_tensor_name, timeout=10.0, model_name=None):
         request = predict_pb2.PredictRequest()
-        request.model_spec.name = model_name
+        request.model_spec.name = model_name or 'model'
 
         copy_message(tf.contrib.util.make_tensor_proto(input_data), request.inputs[input_tensor_name])
         response = self.execute(request, timeout=timeout)

--- a/tensorflow_serving_client/client.py
+++ b/tensorflow_serving_client/client.py
@@ -1,37 +1,24 @@
 import tensorflow as tf
-import numpy as np
 
 from grpc.beta import implementations
-from PIL import Image
-
 from tensorflow_serving_client.protos import prediction_service_pb2, predict_pb2
 from tensorflow_serving_client.proto_util import copy_message
 
 
 class TensorflowServingClient(object):
 
-    def __init__(self, host, port, model_name, target_size):
+    def __init__(self, host, port):
         self.host = host
         self.port = port
-        self.model_name = model_name
-        self.target_size = target_size
-
         self.channel = implementations.insecure_channel(self.host, self.port)
         self.stub = prediction_service_pb2.beta_create_PredictionService_stub(self.channel)
-
-    def classify_image(self, image_path, input_tensor_name='image', timeout=10.0, image_preprocessor=None):
-        img = self._load_image(image_path, target_size=self.target_size)
-        if image_preprocessor:
-            img = image_preprocessor(img)
-        image_data = np.expand_dims(np.asarray(img, dtype=np.float32), axis=0)
-        return self.make_prediction(image_data, input_tensor_name, timeout=timeout)
 
     def execute(self, request, timeout=10.0):
         return self.stub.Predict(request, timeout)
 
-    def make_prediction(self, input_data, input_tensor_name, timeout=10.0):
+    def make_prediction(self, input_data, input_tensor_name, timeout=10.0, model_name='model'):
         request = predict_pb2.PredictRequest()
-        request.model_spec.name = self.model_name
+        request.model_spec.name = model_name
 
         copy_message(tf.contrib.util.make_tensor_proto(input_data), request.inputs[input_tensor_name])
         response = self.execute(request, timeout=timeout)
@@ -40,16 +27,6 @@ class TensorflowServingClient(object):
         for key in response.outputs:
             tensor_proto = response.outputs[key]
             nd_array = tf.contrib.util.make_ndarray(tensor_proto)
-            results[key] = nd_array.tolist()
+            results[key] = nd_array
 
         return results
-
-    def _load_image(self, path, target_size=None):
-        img = Image.open(path)
-        if img.mode != 'RGB':
-            img = img.convert('RGB')
-        if target_size:
-            height_width = (target_size[1], target_size[0])
-            if img.size != height_width:
-                img = img.resize(height_width)
-        return img

--- a/tensorflow_serving_client/utils.py
+++ b/tensorflow_serving_client/utils.py
@@ -3,14 +3,50 @@ import numpy as np
 from PIL import Image
 
 
-def preprocess_input(x):
+def normalized_preprocess_input(x):
     x /= 255.
     x -= 0.5
     x *= 2.
     return x
 
 
-def load_image(image_path, target_size=None):
+def imagenet_preprocess_input(x):
+    x = x[:, :, :, ::-1]
+    x[:, :, :, 0] -= 103.939
+    x[:, :, :, 1] -= 116.779
+    x[:, :, :, 2] -= 123.68
+    return x
+
+
+MODEL_SPECS = {
+    'inception_v3': {
+        'target_size': (299, 299),
+        'preprocess_input': normalized_preprocess_input,
+    },
+    'xception': {
+        'target_size': (299, 299),
+        'preprocess_input': normalized_preprocess_input,
+    },
+    'mobilenet_v1': {
+        'target_size': (224, 224),
+        'preprocess_input': normalized_preprocess_input,
+    },
+    'resnet50': {
+        'target_size': (224, 224),
+        'preprocess_input': imagenet_preprocess_input,
+    },
+    'vgg16': {
+        'target_size': (224, 224),
+        'preprocess_input': imagenet_preprocess_input,
+    },
+    'vgg19': {
+        'target_size': (224, 224),
+        'preprocess_input': imagenet_preprocess_input,
+    },
+}
+
+
+def load_image(image_path, target_size=None, preprocess_input=None):
     img = Image.open(image_path)
     if img.mode != 'RGB':
         img = img.convert('RGB')
@@ -19,6 +55,7 @@ def load_image(image_path, target_size=None):
         if img.size != width_height:
             img = img.resize(width_height)
     image_data = np.asarray(img, dtype=np.float32)
-    image_data = preprocess_input(image_data)
     image_data = np.expand_dims(image_data, axis=0)
+    if preprocess_input:
+        image_data = preprocess_input(image_data)
     return image_data

--- a/tensorflow_serving_client/utils.py
+++ b/tensorflow_serving_client/utils.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from PIL import Image
+
+
+def preprocess_input(x):
+    x /= 255.
+    x -= 0.5
+    x *= 2.
+    return x
+
+
+def load_image(image_path, target_size=None):
+    img = Image.open(image_path)
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
+    if target_size:
+        width_height = (target_size[0], target_size[1])
+        if img.size != width_height:
+            img = img.resize(width_height)
+    image_data = np.asarray(img, dtype=np.float32)
+    image_data = preprocess_input(image_data)
+    image_data = np.expand_dims(image_data, axis=0)
+    return image_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+import csv
+import codecs
+
+from urllib.request import urlopen
+
+
+@pytest.fixture
+def imagenet_dictionary():
+    response = urlopen('https://storage.googleapis.com/tf-serving-docker-http-eae9e0c7-661d-4cca-836a-0433a8da44ba/imagenet/dictionary.csv')
+    reader = csv.reader(codecs.iterdecode(response, 'utf-8'))
+    dictionary = dict(list(reader))
+    return [dictionary[key] for key in sorted(dictionary)]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,36 @@
+import numpy as np
+
+from PIL import Image
 from tensorflow_serving_client import TensorflowServingClient
 
 
-def test_classify_image():
-    client = TensorflowServingClient('localhost', 9000, 'mobilenet_v1-1', (224, 224))
-    result = client.classify_image('tests/fixtures/files/cat.jpg')
-    assert len(result) > 0
+def preprocess_input(x):
+    x /= 255.
+    x -= 0.5
+    x *= 2.
+    return x
+
+
+def load_image(image_path, target_size=None):
+    img = Image.open(image_path)
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
+    if target_size:
+        width_height = (target_size[0], target_size[1])
+        if img.size != width_height:
+            img = img.resize(width_height)
+    image_data = np.asarray(img, dtype=np.float32)
+    image_data = preprocess_input(image_data)
+    image_data = np.expand_dims(image_data, axis=0)
+    return image_data
+
+
+def test_client_make_prediction():
+    client = TensorflowServingClient('localhost', 9000)
+    image = load_image('tests/fixtures/files/cat.jpg', (224, 224))
+    result = client.make_prediction(image, 'image')
+    assert 'class_probabilities' in result
+    assert len(result['class_probabilities']) == 1
+    assert len(result['class_probabilities'][0]) == 7
+    assert len(result['class_probabilities'][0][0]) == 7
+    assert len(result['class_probabilities'][0][0][0]) == 1024

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,28 +1,5 @@
-import numpy as np
-
-from PIL import Image
 from tensorflow_serving_client import TensorflowServingClient
-
-
-def preprocess_input(x):
-    x /= 255.
-    x -= 0.5
-    x *= 2.
-    return x
-
-
-def load_image(image_path, target_size=None):
-    img = Image.open(image_path)
-    if img.mode != 'RGB':
-        img = img.convert('RGB')
-    if target_size:
-        width_height = (target_size[0], target_size[1])
-        if img.size != width_height:
-            img = img.resize(width_height)
-    image_data = np.asarray(img, dtype=np.float32)
-    image_data = preprocess_input(image_data)
-    image_data = np.expand_dims(image_data, axis=0)
-    return image_data
+from tensorflow_serving_client.utils import load_image
 
 
 def test_client_make_prediction():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,23 +1,99 @@
 from tensorflow_serving_client import TensorflowServingClient
-from tensorflow_serving_client.utils import load_image
+from tensorflow_serving_client.utils import load_image, MODEL_SPECS
 
 
-def test_client_make_prediction(imagenet_dictionary):
-    client = TensorflowServingClient('localhost', 9000)
-    image = load_image('tests/fixtures/files/cat.jpg', (224, 224))
-    result = client.make_prediction(image, 'image')
-    assert 'class_probabilities' in result
-    assert len(result['class_probabilities']) == 1
-    assert len(result['class_probabilities'][0]) == 1000
-    predictions = result['class_probabilities'][0]
+MODEL_SERVING_PORTS = {
+    'mobilenet_v1': 9001,
+    'inception_v3': 9002,
+    'xception': 9003,
+    'resnet50': 9004,
+    'vgg16': 9005,
+    'vgg19': 9006,
+}
+
+
+def query_model(model_spec_name):
+    model_spec = MODEL_SPECS[model_spec_name]
+    client = TensorflowServingClient('localhost', MODEL_SERVING_PORTS[model_spec_name])
+    image = load_image('tests/fixtures/files/cat.jpg',
+                       model_spec['target_size'],
+                       model_spec['preprocess_input'])
+    return client.make_prediction(image, 'image')
+
+
+def assert_predictions(response, expected_top_5, imagenet_dictionary):
+    assert 'class_probabilities' in response
+    assert len(response['class_probabilities']) == 1
+    assert len(response['class_probabilities'][0]) == 1000
+    predictions = response['class_probabilities'][0]
     predictions = list(zip(imagenet_dictionary, predictions))
     predictions = sorted(predictions, reverse=True, key=lambda kv: kv[1])[:5]
     predictions = [(label, float(score)) for label, score in predictions]
-    expected = [
+    print(predictions)
+    assert predictions == expected_top_5
+
+
+def test_mobilenet_v1(imagenet_dictionary):
+    response = query_model('mobilenet_v1')
+    assert_predictions(response, [
         ('impala, Aepyceros melampus', 0.334694504737854),
         ('llama', 0.2851393222808838),
         ('hartebeest', 0.15471667051315308),
         ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.03160465136170387),
         ('mink', 0.030886519700288773),
-    ]
-    assert predictions == expected
+    ], imagenet_dictionary)
+
+
+def test_inception_v3(imagenet_dictionary):
+    response = query_model('inception_v3')
+    assert_predictions(response, [
+        ('impala, Aepyceros melampus', 0.4716886878013611),
+        ('llama', 0.127954363822937),
+        ('fox squirrel, eastern fox squirrel, Sciurus niger', 0.07338221371173859),
+        ('hartebeest', 0.052391838282346725),
+        ('marmot', 0.008323794230818748),
+    ], imagenet_dictionary)
+
+
+def test_xception(imagenet_dictionary):
+    response = query_model('xception')
+    assert_predictions(response, [
+        ('ram, tup', 0.10058529675006866),
+        ('Band Aid', 0.09152575582265854),
+        ('fox squirrel, eastern fox squirrel, Sciurus niger', 0.07581676542758942),
+        ('impala, Aepyceros melampus', 0.0746716633439064),
+        ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.06751589477062225),
+    ], imagenet_dictionary)
+
+
+def test_resnet50(imagenet_dictionary):
+    response = query_model('resnet50')
+    assert_predictions(response, [
+        ('ram, tup', 0.3193315863609314),
+        ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.19359852373600006),
+        ('Band Aid', 0.14291106164455414),
+        ('fox squirrel, eastern fox squirrel, Sciurus niger', 0.1395975947380066),
+        ('mink', 0.04618712514638901),
+    ], imagenet_dictionary)
+
+
+def test_vgg16(imagenet_dictionary):
+    response = query_model('vgg16')
+    assert_predictions(response, [
+        ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.3090206980705261),
+        ('ram, tup', 0.21598483622074127),
+        ('llama', 0.1327403038740158),
+        ('impala, Aepyceros melampus', 0.11005250364542007),
+        ('hartebeest', 0.08285804092884064),
+    ], imagenet_dictionary)
+
+
+def test_vgg19(imagenet_dictionary):
+    response = query_model('vgg19')
+    assert_predictions(response, [
+        ('ram, tup', 0.3812929391860962),
+        ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.27262774109840393),
+        ('impala, Aepyceros melampus', 0.08553500473499298),
+        ('mink', 0.05379556491971016),
+        ('llama', 0.047869954258203506),
+    ], imagenet_dictionary)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,12 +2,22 @@ from tensorflow_serving_client import TensorflowServingClient
 from tensorflow_serving_client.utils import load_image
 
 
-def test_client_make_prediction():
+def test_client_make_prediction(imagenet_dictionary):
     client = TensorflowServingClient('localhost', 9000)
     image = load_image('tests/fixtures/files/cat.jpg', (224, 224))
     result = client.make_prediction(image, 'image')
     assert 'class_probabilities' in result
     assert len(result['class_probabilities']) == 1
-    assert len(result['class_probabilities'][0]) == 7
-    assert len(result['class_probabilities'][0][0]) == 7
-    assert len(result['class_probabilities'][0][0][0]) == 1024
+    assert len(result['class_probabilities'][0]) == 1000
+    predictions = result['class_probabilities'][0]
+    predictions = list(zip(imagenet_dictionary, predictions))
+    predictions = sorted(predictions, reverse=True, key=lambda kv: kv[1])[:5]
+    predictions = [(label, float(score)) for label, score in predictions]
+    expected = [
+        ('impala, Aepyceros melampus', 0.334694504737854),
+        ('llama', 0.2851393222808838),
+        ('hartebeest', 0.15471667051315308),
+        ('bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis', 0.03160465136170387),
+        ('mink', 0.030886519700288773),
+    ]
+    assert predictions == expected


### PR DESCRIPTION
 - Remove the `classify_image` abstraction from the client, leave image preprocessing that to the user
 - Add tests for the other 5 model types; inception_v3, xception, resnet50, vgg16, vgg19
 - Add `utils.py` with models specs (`target_size`, `preprocess_input`) for the 6 model types
 - Add tests that assert human read-able classes from imagenet dictionary